### PR TITLE
fix auto npm deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "typescript": "^4.8.3",
     "semantic-release": "^19.0.5"
   },
+  "release": {
+    "branches": [
+      "main"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/rluvaton/node-boilerplate.git"


### PR DESCRIPTION
This will fix the following error:
```
This may occur if your repository does not have a release branch, such as master.

Your configuration for the problematic branches is [].

AggregateError: 
    SemanticReleaseError: The release branches are invalid in the `branches` configuration.
```